### PR TITLE
feat/misc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 apis:
 	cd $(dirname $0)
-	git clone https://github.com/hu-tao-supremacy/apis.git
+	git clone https://github.com/hu-tao-supremacy/api.git apis
 	python3 sym.py

--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ code .
 go run ./cmd/*.go
 ```
 
+## Build binary file
+1. Run go build command
+```
+go build -o main ./cmd/*.go
+```
+2. Execute binary file
+```
+./main
+```
+
 ## WSL2 guide
 - make sure you have setup docker desktop and connected to wsl2
 - for connecting with wls2's grpc port  from windows

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ code .
 ```
 5. Run
 ```
-go run cmd/main.go
+go run ./cmd/*.go
 ```
 
 ## WSL2 guide

--- a/cmd/helper.go
+++ b/cmd/helper.go
@@ -7,5 +7,12 @@ import (
 
 // hasPermission is mock function for account.hasPermission
 func hasPermission(UserID int64, OrganizationID int64, PermissionName common.Permission) bool {
+	// time.Sleep(1 * time.Second)
+	return true
+}
+
+// hasPermission is mock function for account.hasPermission
+func hasEvent(UserID int64, OrganizationID int64, PermissionName int64) bool {
+	// time.Sleep(1 * time.Second)
 	return true
 }

--- a/cmd/helper.go
+++ b/cmd/helper.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	_ "github.com/lib/pq"
+	common "onepass.app/facility/hts/common"
+)
+
+// hasPermission is mock function for account.hasPermission
+func hasPermission(UserID int64, OrganizationID int64, PermissionName common.Permission) bool {
+	return true
+}

--- a/cmd/helper.go
+++ b/cmd/helper.go
@@ -20,12 +20,12 @@ func hasEvent(UserID int64, OrganizationID int64, PermissionName int64) bool {
 }
 
 // isAbleToCreateFacilityRequest is function to check if a facility is able to book according to user psermission
-func isAbleToCreateFacilityRequest(fs *FacilityServer, in *facility.CreateFacilityRequestRequest, permssion common.Permission) (bool, typing.CustomError) {
+func isAbleToCreateFacilityRequest(fs *FacilityServer, in *facility.CreateFacilityRequestRequest, permission common.Permission) (bool, typing.CustomError) {
 	havingPermissionChannel := make(chan bool)
 	eventOwnerChannel := make(chan bool)
 	overlapTimeChannel := make(chan bool)
 	errorChannel := make(chan typing.CustomError)
-	go func() { havingPermissionChannel <- hasPermission(in.UserId, in.OrganizationId, permssion) }()
+	go func() { havingPermissionChannel <- hasPermission(in.UserId, in.OrganizationId, permission) }()
 	go func() { eventOwnerChannel <- hasEvent(in.UserId, in.OrganizationId, in.EventId) }()
 	go func() {
 		isTimeOverlap, err := fs.dbs.IsOverLapTime(in.FacilityId, in.Start, in.End)
@@ -44,7 +44,48 @@ func isAbleToCreateFacilityRequest(fs *FacilityServer, in *facility.CreateFacili
 	close(errorChannel)
 
 	if !(isPermission && isEventOwner) {
-		return false, &typing.PermissionError{Type: permssion}
+		return false, &typing.PermissionError{Type: permission}
+	}
+
+	if overalpErr != nil {
+		return false, overalpErr
+	}
+	if isTimeOverlap {
+		return false, &typing.AlreadyExistError{Name: "Facility is booked at that time"}
+	}
+
+	return true, nil
+}
+
+// isAbleToApproveFacilityRequest is function to check if a facility is able to be approve according to user psermission
+func isAbleToApproveFacilityRequest(fs *FacilityServer, in *facility.ApproveFacilityRequestRequest, permission common.Permission) (bool, typing.CustomError) {
+	havingPermissionChannel := make(chan bool)
+	overlapTimeChannel := make(chan bool)
+	errorChannel := make(chan typing.CustomError)
+
+	go func() { havingPermissionChannel <- hasPermission(in.UserId, in.OrganizationId, permission) }()
+	go func() {
+		facilityRequest, err := fs.dbs.GetFacilityRequest(in.RequestId)
+		if err != nil {
+			errorChannel <- err
+			return
+		}
+
+		isTimeOverlap, err := fs.dbs.IsOverLapTime(facilityRequest.FacilityId, facilityRequest.Start, facilityRequest.Finish)
+		overlapTimeChannel <- isTimeOverlap
+		errorChannel <- err
+	}()
+
+	isPermission := <-havingPermissionChannel
+	isTimeOverlap := <-overlapTimeChannel
+	overalpErr := <-errorChannel
+
+	close(havingPermissionChannel)
+	close(overlapTimeChannel)
+	close(errorChannel)
+
+	if !(isPermission) {
+		return false, &typing.PermissionError{Type: permission}
 	}
 
 	if overalpErr != nil {

--- a/cmd/helper.go
+++ b/cmd/helper.go
@@ -11,7 +11,7 @@ func hasPermission(UserID int64, OrganizationID int64, PermissionName common.Per
 	return true
 }
 
-// hasPermission is mock function for account.hasPermission
+// hasEvent is mock function for organization.hasEvent
 func hasEvent(UserID int64, OrganizationID int64, PermissionName int64) bool {
 	// time.Sleep(1 * time.Second)
 	return true

--- a/cmd/helper.go
+++ b/cmd/helper.go
@@ -3,6 +3,8 @@ package main
 import (
 	_ "github.com/lib/pq"
 	common "onepass.app/facility/hts/common"
+	facility "onepass.app/facility/hts/facility"
+	typing "onepass.app/facility/internal/typing"
 )
 
 // hasPermission is mock function for account.hasPermission
@@ -15,4 +17,42 @@ func hasPermission(UserID int64, OrganizationID int64, PermissionName common.Per
 func hasEvent(UserID int64, OrganizationID int64, PermissionName int64) bool {
 	// time.Sleep(1 * time.Second)
 	return true
+}
+
+// isAbleToCreateFacilityRequest is function to check if a facility is able to book according to user psermission
+func isAbleToCreateFacilityRequest(fs *FacilityServer, in *facility.CreateFacilityRequestRequest, permssion common.Permission) (bool, typing.CustomError) {
+	havingPermissionChannel := make(chan bool)
+	eventOwnerChannel := make(chan bool)
+	overlapTimeChannel := make(chan bool)
+	errorChannel := make(chan typing.CustomError)
+	go func() { havingPermissionChannel <- hasPermission(in.UserId, in.OrganizationId, permssion) }()
+	go func() { eventOwnerChannel <- hasEvent(in.UserId, in.OrganizationId, in.EventId) }()
+	go func() {
+		isTimeOverlap, err := fs.dbs.IsOverLapTime(in.FacilityId, in.Start, in.End)
+		overlapTimeChannel <- isTimeOverlap
+		errorChannel <- err
+	}()
+
+	isPermission := <-havingPermissionChannel
+	isEventOwner := <-eventOwnerChannel
+	isTimeOverlap := <-overlapTimeChannel
+	overalpErr := <-errorChannel
+
+	close(havingPermissionChannel)
+	close(eventOwnerChannel)
+	close(overlapTimeChannel)
+	close(errorChannel)
+
+	if !(isPermission && isEventOwner) {
+		return false, &typing.PermissionError{Type: permssion}
+	}
+
+	if overalpErr != nil {
+		return false, overalpErr
+	}
+	if isTimeOverlap {
+		return false, &typing.AlreadyExistError{Name: "Facility is booked at that time"}
+	}
+
+	return true, nil
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,10 +9,12 @@ import (
 	empty "github.com/golang/protobuf/ptypes/empty"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"onepass.app/facility/hts/common"
 	facility "onepass.app/facility/hts/facility"
 	database "onepass.app/facility/internal/database"
+	typing "onepass.app/facility/internal/typing"
 
 	_ "github.com/lib/pq"
 )
@@ -50,7 +52,7 @@ func (fs *FacilityServer) GetAvailableFacilityList(ctx context.Context, in *empt
 }
 
 // GetFacilityInfo is a function to get facility’s information
-func (fs *FacilityServer) GetFacilityInfo(ctx context.Context, in *facility.GetFacilityInfoRequest) (*facility.Facility, error) {
+func (fs *FacilityServer) GetFacilityInfo(ctx context.Context, in *facility.GetFacilityInfoRequest) (*common.Facility, error) {
 	result, err := fs.dbs.GetFacilityInfo(in.FacilityId)
 
 	if err != nil {
@@ -60,8 +62,35 @@ func (fs *FacilityServer) GetFacilityInfo(ctx context.Context, in *facility.GetF
 	return result, nil
 }
 
+// ApproveFacilityRequest is a function to reject facility’s request by id
+func (fs *FacilityServer) ApproveFacilityRequest(ctx context.Context, in *facility.ApproveFacilityRequestRequest) (*common.Result, error) {
+	permission := common.Permission_UPDATE_FACILITY
+	isAbleToApproveRequest := hasPermission(in.UserId, in.OrganizationId, permission)
+	if !isAbleToApproveRequest {
+		return nil, status.Error(codes.PermissionDenied, (&typing.PermissionError{Type: permission}).Error())
+	}
+
+	err := fs.dbs.ApproveFacilityRequest(in.RequestId)
+
+	if err != nil {
+		return nil, status.Error(err.StatusCode, err.Error())
+	}
+
+	description := fmt.Sprintf("Request ID: %d has been aproved", in.RequestId)
+	return &common.Result{
+		IsOk:        true,
+		Description: description,
+	}, nil
+}
+
 // RejectFacilityRequest is a function to reject facility’s request by id
 func (fs *FacilityServer) RejectFacilityRequest(ctx context.Context, in *facility.RejectFacilityRequestRequest) (*common.Result, error) {
+	permission := common.Permission_UPDATE_FACILITY
+	isAbleToRejectRequest := hasPermission(in.UserId, in.OrganizationId, permission)
+	if !isAbleToRejectRequest {
+		return nil, status.Error(codes.PermissionDenied, (&typing.PermissionError{Type: permission}).Error())
+	}
+
 	err := fs.dbs.RejectFacilityRequest(in.RequestId, in.Reason)
 
 	if err != nil {
@@ -76,7 +105,13 @@ func (fs *FacilityServer) RejectFacilityRequest(ctx context.Context, in *facilit
 }
 
 // CreateFacilityRequest is a function to create facility’s request by id
-func (fs *FacilityServer) CreateFacilityRequest(ctx context.Context, in *facility.CreateFacilityRequestRequest) (*facility.FacilityRequest, error) {
+func (fs *FacilityServer) CreateFacilityRequest(ctx context.Context, in *facility.CreateFacilityRequestRequest) (*common.FacilityRequest, error) {
+	permssion := common.Permission_UPDATE_EVENT
+	isAbleToCreateRequest := hasPermission(in.UserId, in.OrganizationId, permssion)
+	if !isAbleToCreateRequest {
+		return nil, status.Error(codes.PermissionDenied, (&typing.PermissionError{Type: permssion}).Error())
+	}
+
 	result, err := fs.dbs.CreateFacilityRequest(in.EventId, in.FacilityId, in.Start, in.End)
 
 	if err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,6 +41,7 @@ func (fs *FacilityServer) GetFacilityList(ctx context.Context, in *facility.GetF
 // GetAvailableFacilityList is a function to list all available facilities
 func (fs *FacilityServer) GetAvailableFacilityList(ctx context.Context, in *empty.Empty) (*facility.GetAvailableFacilityListResponse, error) {
 	list, err := fs.dbs.GetAvailableFacilityList()
+	log.Println(err, list)
 
 	if err != nil {
 		return nil, status.Error(err.StatusCode, err.Error())

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,7 +41,6 @@ func (fs *FacilityServer) GetFacilityList(ctx context.Context, in *facility.GetF
 // GetAvailableFacilityList is a function to list all available facilities
 func (fs *FacilityServer) GetAvailableFacilityList(ctx context.Context, in *empty.Empty) (*facility.GetAvailableFacilityListResponse, error) {
 	list, err := fs.dbs.GetAvailableFacilityList()
-	log.Println(err, list)
 
 	if err != nil {
 		return nil, status.Error(err.StatusCode, err.Error())

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"log"
 	"net"
 
@@ -11,6 +12,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"onepass.app/facility/hts/common"
 	facility "onepass.app/facility/hts/facility"
 	database "onepass.app/facility/internal/database"
 
@@ -60,6 +62,24 @@ func (fs *FacilityServer) GetFacilityInfo(ctx context.Context, in *facility.GetF
 		return nil, status.Error(codes.Internal, err.Error())
 	default:
 		return result, nil
+	}
+}
+
+// RejectFacilityRequest is a function to reject facility’s request by id
+func (fs *FacilityServer) RejectFacilityRequest(ctx context.Context, in *facility.RejectFacilityRequestRequest) (*common.Result, error) {
+	err := fs.dbs.RejectFacilityRequest(in.RequestId, in.Reason)
+
+	switch {
+	case err == sql.ErrNoRows:
+		return nil, status.Error(codes.NotFound, err.Error())
+	case err != nil:
+		return nil, status.Error(codes.Internal, err.Error())
+	default:
+		description := fmt.Sprintf("Request ID: %d has been rejected", in.RequestId)
+		return &common.Result{
+			IsOk:        true,
+			Description: description,
+		}, nil
 	}
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -75,8 +75,8 @@ func (fs *FacilityServer) RejectFacilityRequest(ctx context.Context, in *facilit
 	}, nil
 }
 
-// RequestFacilityRequest is a function to create facility’s request by id
-func (fs *FacilityServer) RequestFacilityRequest(ctx context.Context, in *facility.RequestFacilityRequestRequest) (*facility.FacilityRequest, error) {
+// CreateFacilityRequest is a function to create facility’s request by id
+func (fs *FacilityServer) CreateFacilityRequest(ctx context.Context, in *facility.CreateFacilityRequestRequest) (*facility.FacilityRequest, error) {
 	result, err := fs.dbs.CreateFacilityRequest(in.EventId, in.FacilityId, in.Start, in.End)
 
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/golang/protobuf v1.4.2
+	github.com/iancoleman/strcase v0.1.3
 	github.com/jmoiron/sqlx v1.3.1
 	github.com/lib/pq v1.9.0
 	google.golang.org/grpc v1.35.0

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/iancoleman/strcase v0.1.3 h1:dJBk1m2/qjL1twPLf68JND55vvivMupZ4wIzE8CTdBw=
+github.com/iancoleman/strcase v0.1.3/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
 github.com/jmoiron/sqlx v1.3.1 h1:aLN7YINNZ7cYOPK3QC83dbM6KT0NMqVMw961TqrejlE=
 github.com/jmoiron/sqlx v1.3.1/go.mod h1:2BljVx/86SuTyjE+aPYlHCTNvZrnJXghYGpNiXLBMCQ=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=

--- a/internal/database/helper.go
+++ b/internal/database/helper.go
@@ -1,30 +1,18 @@
 package database
 
 import (
-	"google.golang.org/protobuf/types/known/wrapperspb"
-	facility "onepass.app/facility/hts/facility"
+	common "onepass.app/facility/hts/common"
 	model "onepass.app/facility/internal/model"
 )
 
-func convertFacilityModelToProto(data *model.Facility) *facility.Facility {
-	var operatingHours, description *wrapperspb.StringValue
-	if data.OperatingHours.Valid {
-		operatingHours = &wrapperspb.StringValue{
-			Value: data.OperatingHours.String,
-		}
-	}
-	if data.Description.Valid {
-		description = &wrapperspb.StringValue{
-			Value: data.Description.String,
-		}
-	}
-	return &facility.Facility{
+func convertFacilityModelToProto(data *model.Facility) *common.Facility {
+	return &common.Facility{
 		Id:             data.ID,
 		OrganizationId: data.OrganizationID,
 		Name:           data.Name,
 		Latitude:       data.Latitude,
 		Longitude:      data.Longitude,
-		OperatingHours: operatingHours,
-		Description:    description,
+		OperatingHours: data.OperatingHours,
+		Description:    data.Description,
 	}
 }

--- a/internal/database/helper.go
+++ b/internal/database/helper.go
@@ -1,26 +1,12 @@
 package database
 
 import (
-	"regexp"
 	"strings"
 
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	facility "onepass.app/facility/hts/facility"
 	model "onepass.app/facility/internal/model"
 )
-
-var camelRegex = regexp.MustCompile("[A-Z]?[a-z0-9]+")
-
-func camelToSnakeCase(str string) string {
-	matches := camelRegex.FindAllString(str, -1)
-	lowers := make([]string, len(matches))
-
-	for i, match := range matches {
-		lowers[i] = strings.ToLower(match)
-	}
-
-	return strings.Join(lowers, "_")
-}
 
 func convertFacilityModelToProto(data *model.Facility) *facility.Facility {
 	var operatingHours, description *wrapperspb.StringValue

--- a/internal/database/helper.go
+++ b/internal/database/helper.go
@@ -1,0 +1,46 @@
+package database
+
+import (
+	"regexp"
+	"strings"
+
+	"google.golang.org/protobuf/types/known/wrapperspb"
+	facility "onepass.app/facility/hts/facility"
+	model "onepass.app/facility/internal/model"
+)
+
+var camelRegex = regexp.MustCompile("[A-Z]?[a-z0-9]+")
+
+func camelToSnakeCase(str string) string {
+	matches := camelRegex.FindAllString(str, -1)
+	lowers := make([]string, len(matches))
+
+	for i, match := range matches {
+		lowers[i] = strings.ToLower(match)
+	}
+
+	return strings.Join(lowers, "_")
+}
+
+func convertFacilityModelToProto(data *model.Facility) *facility.Facility {
+	var operatingHours, description *wrapperspb.StringValue
+	if data.OperatingHours.Valid {
+		operatingHours = &wrapperspb.StringValue{
+			Value: data.OperatingHours.String,
+		}
+	}
+	if data.Description.Valid {
+		description = &wrapperspb.StringValue{
+			Value: data.Description.String,
+		}
+	}
+	return &facility.Facility{
+		Id:             data.ID,
+		OrganizationId: data.OrganizationID,
+		Name:           data.Name,
+		Latitude:       data.Latitude,
+		Longitude:      data.Longitude,
+		OperatingHours: operatingHours,
+		Description:    description,
+	}
+}

--- a/internal/database/helper.go
+++ b/internal/database/helper.go
@@ -1,6 +1,8 @@
 package database
 
 import (
+	"github.com/golang/protobuf/ptypes/wrappers"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	common "onepass.app/facility/hts/common"
 	model "onepass.app/facility/internal/model"
 )
@@ -14,5 +16,21 @@ func convertFacilityModelToProto(data *model.Facility) *common.Facility {
 		Longitude:      data.Longitude,
 		OperatingHours: data.OperatingHours,
 		Description:    data.Description,
+	}
+}
+
+func convertFacilityRequestModelToProto(data *model.FacilityRequest) *common.FacilityRequest {
+	var rejectReason *wrappers.StringValue
+	if data.RejectReason.Valid {
+		rejectReason = &wrappers.StringValue{Value: data.RejectReason.String}
+	}
+	return &common.FacilityRequest{
+		Id:           data.ID,
+		EventId:      data.EventID,
+		FacilityId:   data.FacilityID,
+		Status:       common.Status(common.Status_value[data.Status]),
+		RejectReason: rejectReason,
+		Start:        timestamppb.New(data.Start),
+		Finish:       timestamppb.New(data.Finish),
 	}
 }

--- a/internal/database/helper.go
+++ b/internal/database/helper.go
@@ -1,8 +1,6 @@
 package database
 
 import (
-	"strings"
-
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	facility "onepass.app/facility/hts/facility"
 	model "onepass.app/facility/internal/model"

--- a/internal/database/main.go
+++ b/internal/database/main.go
@@ -7,10 +7,13 @@ import (
 	"os"
 	"strings"
 
+	"github.com/golang/protobuf/ptypes"
 	"github.com/jmoiron/sqlx/reflectx"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	facility "onepass.app/facility/hts/facility"
+	typing "onepass.app/facility/internal/typing"
 
 	"github.com/jmoiron/sqlx"
 )
@@ -21,64 +24,158 @@ type DataService struct {
 }
 
 // GetFacilityList is a function to get facility list owned by the organization from database
-func (dbs *DataService) GetFacilityList(organizationID int64) ([]*facility.Facility, error) {
+func (dbs *DataService) GetFacilityList(organizationID int64) ([]*facility.Facility, *typing.DatabaseError) {
 	var facilities []*facility.Facility
 	query := fmt.Sprintf("SELECT * FROM facility WHERE facility.organization_id = %d;", organizationID)
 	err := dbs.SQL.Select(&facilities, query)
 
 	if err != nil {
-		return nil, err
+		return nil, &typing.DatabaseError{
+			Err:        err,
+			StatusCode: codes.Internal,
+		}
 	}
 
 	return facilities, nil
 }
 
 // GetAvailableFacilityList is a function to list all available facilities
-func (dbs *DataService) GetAvailableFacilityList() ([]*facility.Facility, error) {
+func (dbs *DataService) GetAvailableFacilityList() ([]*facility.Facility, *typing.DatabaseError) {
 	var facilities []*facility.Facility
 	query := "SELECT * FROM facility"
 	err := dbs.SQL.Select(&facilities, query)
 
 	if err != nil {
-		return nil, err
+		return nil, &typing.DatabaseError{
+			Err:        err,
+			StatusCode: codes.Internal,
+		}
 	}
 
 	return facilities, nil
 }
 
 // GetFacilityInfo is a function to get facility’s information by id
-func (dbs *DataService) GetFacilityInfo(facilityID int64) (*facility.Facility, error) {
+func (dbs *DataService) GetFacilityInfo(facilityID int64) (*facility.Facility, *typing.DatabaseError) {
 	var _facility facility.Facility
 	query := fmt.Sprintf("SELECT * FROM facility WHERE facility.id = %d", facilityID)
 	err := dbs.SQL.Get(&_facility, query)
 
-	if err != nil {
-		return nil, err
+	switch {
+	case err == sql.ErrNoRows:
+		return nil, &typing.DatabaseError{
+			Err:        &typing.NotFoundError{Name: "facility"},
+			StatusCode: codes.NotFound,
+		}
+	case err != nil:
+		return nil, &typing.DatabaseError{
+			Err:        err,
+			StatusCode: codes.Internal,
+		}
+	default:
+		return &_facility, nil
 	}
 
-	return &_facility, nil
 }
 
+// add reason
+
 // RejectFacilityRequest is a function to reject facility’s request by id
-func (dbs *DataService) RejectFacilityRequest(requestID int64, reason string) error {
+func (dbs *DataService) RejectFacilityRequest(requestID int64, reason string) *typing.DatabaseError {
 	query := "UPDATE facility_request SET status=:status WHERE facility_request.id = :id"
 	result, err := dbs.SQL.NamedExec(query, map[string]interface{}{
 		"id":     requestID,
 		"status": "REJECTED",
 	})
 	if err != nil {
-		return err
+		return &typing.DatabaseError{
+			Err:        err,
+			StatusCode: codes.Internal,
+		}
 	}
 
 	count, err := result.RowsAffected()
-	if err != nil {
-		return err
+	switch {
+	case err != nil:
+		return &typing.DatabaseError{
+			Err:        err,
+			StatusCode: codes.Internal,
+		}
+	case count != 1:
+		return &typing.DatabaseError{
+			Err:        &typing.NotFoundError{Name: "FacilityRequest"},
+			StatusCode: codes.NotFound,
+		}
+	default:
+		return nil
 	}
-	if count != 1 {
-		return sql.ErrNoRows
+}
+
+// ApproveFacilityRequest is a function to approve facility request
+func (dbs *DataService) ApproveFacilityRequest(requestID int64) *typing.DatabaseError {
+	query := "UPDATE facility_request SET status=:status WHERE facility_request.id = :id"
+	result, err := dbs.SQL.NamedExec(query, map[string]interface{}{
+		"id":     requestID,
+		"status": "APPROVED",
+	})
+	if err != nil {
+		return &typing.DatabaseError{
+			Err:        err,
+			StatusCode: codes.Internal,
+		}
 	}
 
-	return nil
+	count, err := result.RowsAffected()
+	switch {
+	case err != nil:
+		return &typing.DatabaseError{
+			Err:        err,
+			StatusCode: codes.Internal,
+		}
+	case count != 1:
+		return &typing.DatabaseError{
+			Err:        &typing.NotFoundError{Name: "FacilityRequest"},
+			StatusCode: codes.NotFound,
+		}
+	default:
+		return nil
+	}
+}
+
+// CreateFacilityRequest is a function to create facilityRequest
+func (dbs *DataService) CreateFacilityRequest(eventID int64, facilityID int64, start *timestamppb.Timestamp, finish *timestamppb.Timestamp) (*facility.FacilityRequest, *typing.DatabaseError) {
+	var id int64
+	query := "INSERT INTO facility_request (event_id, facility_id, status, start, finish) VALUES (:event_id, :facility_id, :status, :start, :finish) RETURNING id"
+	startTime, _ := ptypes.Timestamp(start)
+	finishTime, _ := ptypes.Timestamp(finish)
+	rows, err := dbs.SQL.NamedQuery(query, map[string]interface{}{
+		"event_id":    eventID,
+		"facility_id": facilityID,
+		"status":      "PENDING",
+		"start":       startTime,
+		"finish":      finishTime,
+	})
+	if rows.Next() {
+		rows.Scan(&id)
+	}
+
+	if err != nil {
+		return nil, &typing.DatabaseError{
+			Err:        err,
+			StatusCode: codes.Internal,
+		}
+	}
+
+	result := facility.FacilityRequest{
+		Id:         id,
+		EventId:    eventID,
+		FacilityId: facilityID,
+		Status:     facility.RequestStatus_PENDING,
+		Start:      start,
+		Finish:     finish,
+	}
+
+	return &result, nil
 }
 
 func (dbs *DataService) ping() (string, error) {

--- a/internal/database/main.go
+++ b/internal/database/main.go
@@ -26,7 +26,7 @@ type DataService struct {
 }
 
 // GetFacilityList is a function to get facility list owned by the organization from database
-func (dbs *DataService) GetFacilityList(organizationID int64) ([]*common.Facility, *typing.DatabaseError) {
+func (dbs *DataService) GetFacilityList(organizationID int64) ([]*common.Facility, typing.CustomError) {
 	var facilities []*model.Facility
 	query := fmt.Sprintf(`
 	SELECT * 
@@ -51,7 +51,7 @@ func (dbs *DataService) GetFacilityList(organizationID int64) ([]*common.Facilit
 }
 
 // GetAvailableFacilityList is a function to list all available facilities
-func (dbs *DataService) GetAvailableFacilityList() ([]*common.Facility, *typing.DatabaseError) {
+func (dbs *DataService) GetAvailableFacilityList() ([]*common.Facility, typing.CustomError) {
 	var facilities []*model.Facility
 	query := `
 	SELECT * 
@@ -74,7 +74,7 @@ func (dbs *DataService) GetAvailableFacilityList() ([]*common.Facility, *typing.
 }
 
 // GetFacilityInfo is a function to get facility’s information by id
-func (dbs *DataService) GetFacilityInfo(facilityID int64) (*common.Facility, *typing.DatabaseError) {
+func (dbs *DataService) GetFacilityInfo(facilityID int64) (*common.Facility, typing.CustomError) {
 	var _facility model.Facility
 	query := fmt.Sprintf(`
 	SELECT * 
@@ -99,7 +99,7 @@ func (dbs *DataService) GetFacilityInfo(facilityID int64) (*common.Facility, *ty
 	}
 }
 
-func (dbs *DataService) updateFacilityRequest(requestID int64, status common.Status, reason *wrapperspb.StringValue) *typing.DatabaseError {
+func (dbs *DataService) updateFacilityRequest(requestID int64, status common.Status, reason *wrapperspb.StringValue) typing.CustomError {
 	var queryReason string
 	if reason != nil {
 		queryReason = ", reject_reason=:reason "
@@ -140,17 +140,17 @@ func (dbs *DataService) updateFacilityRequest(requestID int64, status common.Sta
 }
 
 // RejectFacilityRequest is a function to reject facility’s request by id
-func (dbs *DataService) RejectFacilityRequest(requestID int64, reason *wrapperspb.StringValue) *typing.DatabaseError {
+func (dbs *DataService) RejectFacilityRequest(requestID int64, reason *wrapperspb.StringValue) typing.CustomError {
 	return dbs.updateFacilityRequest(requestID, common.Status_REJECTED, reason)
 }
 
 // ApproveFacilityRequest is a function to approve facility request
-func (dbs *DataService) ApproveFacilityRequest(requestID int64) *typing.DatabaseError {
+func (dbs *DataService) ApproveFacilityRequest(requestID int64) typing.CustomError {
 	return dbs.updateFacilityRequest(requestID, common.Status_APPROVED, nil)
 }
 
 // CreateFacilityRequest is a function to create facilityRequest
-func (dbs *DataService) CreateFacilityRequest(eventID int64, facilityID int64, start *timestamppb.Timestamp, finish *timestamppb.Timestamp) (*common.FacilityRequest, *typing.DatabaseError) {
+func (dbs *DataService) CreateFacilityRequest(eventID int64, facilityID int64, start *timestamppb.Timestamp, finish *timestamppb.Timestamp) (*common.FacilityRequest, typing.CustomError) {
 	var id int64
 	query := `
 	INSERT INTO facility_request (event_id, facility_id, status, start, finish) 
@@ -188,7 +188,7 @@ func (dbs *DataService) CreateFacilityRequest(eventID int64, facilityID int64, s
 }
 
 // IsOverLapTime is function to check whether time is overlap with already booked facility
-func (dbs *DataService) IsOverLapTime(facilityID int64, start *timestamppb.Timestamp, finish *timestamppb.Timestamp) (bool, *typing.DatabaseError) {
+func (dbs *DataService) IsOverLapTime(facilityID int64, start *timestamppb.Timestamp, finish *timestamppb.Timestamp) (bool, typing.CustomError) {
 	var count int64
 	startTime, _ := ptypes.Timestamp(start)
 	finishTime, _ := ptypes.Timestamp(finish)
@@ -218,7 +218,7 @@ func (dbs *DataService) IsOverLapTime(facilityID int64, start *timestamppb.Times
 }
 
 // GetFacilityRequest is function to get facility request by id
-func (dbs *DataService) GetFacilityRequest(RequestID int64) (*common.FacilityRequest, *typing.DatabaseError) {
+func (dbs *DataService) GetFacilityRequest(RequestID int64) (*common.FacilityRequest, typing.CustomError) {
 	var facilityRequest model.FacilityRequest
 
 	query := fmt.Sprintf(`

--- a/internal/database/main.go
+++ b/internal/database/main.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"database/sql"
 	"fmt"
 	"log"
 	"os"
@@ -56,6 +57,28 @@ func (dbs *DataService) GetFacilityInfo(facilityID int64) (*facility.Facility, e
 	}
 
 	return &_facility, nil
+}
+
+// RejectFacilityRequest is a function to reject facility’s request by id
+func (dbs *DataService) RejectFacilityRequest(requestID int64, reason string) error {
+	query := "UPDATE facility_request SET status=:status WHERE facility_request.id = :id"
+	result, err := dbs.SQL.NamedExec(query, map[string]interface{}{
+		"id":     requestID,
+		"status": "REJECTED",
+	})
+	if err != nil {
+		return err
+	}
+
+	count, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if count != 1 {
+		return sql.ErrNoRows
+	}
+
+	return nil
 }
 
 func (dbs *DataService) ping() (string, error) {

--- a/internal/database/main.go
+++ b/internal/database/main.go
@@ -28,7 +28,11 @@ type DataService struct {
 // GetFacilityList is a function to get facility list owned by the organization from database
 func (dbs *DataService) GetFacilityList(organizationID int64) ([]*common.Facility, *typing.DatabaseError) {
 	var facilities []*model.Facility
-	query := fmt.Sprintf("SELECT * FROM facility WHERE facility.organization_id = %d;", organizationID)
+	query := fmt.Sprintf(`
+	SELECT * 
+	FROM facility 
+	WHERE facility.organization_id = %d;`,
+		organizationID)
 	err := dbs.SQL.Select(&facilities, query)
 
 	if err != nil {
@@ -49,7 +53,9 @@ func (dbs *DataService) GetFacilityList(organizationID int64) ([]*common.Facilit
 // GetAvailableFacilityList is a function to list all available facilities
 func (dbs *DataService) GetAvailableFacilityList() ([]*common.Facility, *typing.DatabaseError) {
 	var facilities []*model.Facility
-	query := "SELECT * FROM facility"
+	query := `
+	SELECT * 
+	FROM facility`
 	err := dbs.SQL.Select(&facilities, query)
 
 	if err != nil {
@@ -70,7 +76,11 @@ func (dbs *DataService) GetAvailableFacilityList() ([]*common.Facility, *typing.
 // GetFacilityInfo is a function to get facility’s information by id
 func (dbs *DataService) GetFacilityInfo(facilityID int64) (*common.Facility, *typing.DatabaseError) {
 	var _facility model.Facility
-	query := fmt.Sprintf("SELECT * FROM facility WHERE facility.id = %d", facilityID)
+	query := fmt.Sprintf(`
+	SELECT * 
+	FROM facility 
+	WHERE facility.id = %d`,
+		facilityID)
 	err := dbs.SQL.Get(&_facility, query)
 
 	switch {
@@ -95,7 +105,11 @@ func (dbs *DataService) updateFacilityRequest(requestID int64, status common.Sta
 		queryReason = ", reject_reason=:reason "
 	}
 
-	query := fmt.Sprintf("UPDATE facility_request SET status=:status%s WHERE facility_request.id = :id", queryReason)
+	query := fmt.Sprintf(`
+	UPDATE facility_request 
+	SET status=:status%s 
+	WHERE facility_request.id = :id`,
+		queryReason)
 	result, err := dbs.SQL.NamedExec(query, map[string]interface{}{
 		"id":     requestID,
 		"status": status.String(),
@@ -138,7 +152,10 @@ func (dbs *DataService) ApproveFacilityRequest(requestID int64) *typing.Database
 // CreateFacilityRequest is a function to create facilityRequest
 func (dbs *DataService) CreateFacilityRequest(eventID int64, facilityID int64, start *timestamppb.Timestamp, finish *timestamppb.Timestamp) (*common.FacilityRequest, *typing.DatabaseError) {
 	var id int64
-	query := "INSERT INTO facility_request (event_id, facility_id, status, start, finish) VALUES (:event_id, :facility_id, :status, :start, :finish) RETURNING id"
+	query := `
+	INSERT INTO facility_request (event_id, facility_id, status, start, finish) 
+	VALUES (:event_id, :facility_id, :status, :start, :finish) 
+	RETURNING id`
 	startTime, _ := ptypes.Timestamp(start)
 	finishTime, _ := ptypes.Timestamp(finish)
 	rows, err := dbs.SQL.NamedQuery(query, map[string]interface{}{
@@ -180,7 +197,14 @@ func (dbs *DataService) IsOverLapTime(facilityID int64, start *timestamppb.Times
 	startTimeText := startTime.Format(layoutTime)
 	finishTimeText := finishTime.Format(layoutTime)
 
-	query := fmt.Sprintf("SELECT COUNT(*) FROM facility_request WHERE (('%s' >= start AND '%s' < finish) OR ('%s' > start AND '%s' <= finish)) AND facility_id = %d AND status='APPROVED' LIMIT 1;", startTimeText, startTimeText, finishTimeText, finishTimeText, facilityID)
+	query := fmt.Sprintf(`
+	SELECT COUNT(*) 
+	FROM facility_request 
+	WHERE (('%s' >= start AND '%s' < finish) OR ('%s' > start AND '%s' <= finish)) 
+	AND facility_id = %d 
+	AND status='APPROVED' 
+	LIMIT 1;`,
+		startTimeText, startTimeText, finishTimeText, finishTimeText, facilityID)
 	err := dbs.SQL.Get(&count, query)
 
 	if err != nil {
@@ -197,7 +221,12 @@ func (dbs *DataService) IsOverLapTime(facilityID int64, start *timestamppb.Times
 func (dbs *DataService) GetFacilityRequest(RequestID int64) (*common.FacilityRequest, *typing.DatabaseError) {
 	var facilityRequest model.FacilityRequest
 
-	query := fmt.Sprintf("SELECT * FROM facility_request WHERE id=%d LIMIT 1", RequestID)
+	query := fmt.Sprintf(`
+	SELECT * 
+	FROM facility_request 
+	WHERE id=%d 
+	LIMIT 1
+	`, RequestID)
 	err := dbs.SQL.Get(&facilityRequest, query)
 
 	if err != nil {

--- a/internal/database/main.go
+++ b/internal/database/main.go
@@ -32,7 +32,6 @@ func (dbs *DataService) GetFacilityList(organizationID int64) ([]*common.Facilit
 	err := dbs.SQL.Select(&facilities, query)
 
 	if err != nil {
-		log.Println(facilities, query, err)
 		return nil, &typing.DatabaseError{
 			Err:        err,
 			StatusCode: codes.Internal,
@@ -182,7 +181,6 @@ func (dbs *DataService) IsOverLapTime(facilityID int64, start *timestamppb.Times
 	finishTimeText := finishTime.Format(layoutTime)
 
 	query := fmt.Sprintf("SELECT COUNT(*) FROM facility_request WHERE (('%s' >= start AND '%s' < finish) OR ('%s' > start AND '%s' <= finish)) AND facility_id = %d AND status='APPROVED' LIMIT 1;", startTimeText, startTimeText, finishTimeText, finishTimeText, facilityID)
-	print(query)
 	err := dbs.SQL.Get(&count, query)
 
 	if err != nil {

--- a/internal/database/main.go
+++ b/internal/database/main.go
@@ -91,16 +91,16 @@ func (dbs *DataService) GetFacilityInfo(facilityID int64) (*common.Facility, *ty
 }
 
 func (dbs *DataService) updateFacilityRequest(requestID int64, status common.Status, reason *wrapperspb.StringValue) *typing.DatabaseError {
-	var query string
+	var queryReason string
 	if reason != nil {
-		query = "UPDATE facility_request SET status=:status reason=:reason WHERE facility_request.id = :id"
-	} else {
-		query = "UPDATE facility_request SET status=:status WHERE facility_request.id = :id"
+		queryReason = ", reject_reason=:reason "
 	}
+
+	query := fmt.Sprintf("UPDATE facility_request SET status=:status%s WHERE facility_request.id = :id", queryReason)
 	result, err := dbs.SQL.NamedExec(query, map[string]interface{}{
 		"id":     requestID,
-		"status": status,
-		"reason": reason,
+		"status": status.String(),
+		"reason": reason.GetValue(),
 	})
 	if err != nil {
 		return &typing.DatabaseError{

--- a/internal/model/main.go
+++ b/internal/model/main.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
-	"onepass.app/facility/hts/facility"
+	"onepass.app/facility/hts/common"
 )
 
 // Facility is model for database
@@ -12,10 +12,10 @@ type Facility struct {
 	ID             int64
 	OrganizationID int64
 	Name           string
-	Latitude       int64
-	Longitude      int64
-	OperatingHours sql.NullString
-	Description    sql.NullString
+	Latitude       float64
+	Longitude      float64
+	OperatingHours string
+	Description    string
 }
 
 // FacilityRequest is model for database
@@ -23,7 +23,7 @@ type FacilityRequest struct {
 	ID           int64
 	EventID      int64
 	FacilityID   int64
-	Status       facility.RequestStatus
+	Status       common.Status
 	RejectReason sql.NullString
 	Start        *timestamp.Timestamp
 	Finish       *timestamp.Timestamp

--- a/internal/model/main.go
+++ b/internal/model/main.go
@@ -2,9 +2,7 @@ package model
 
 import (
 	"database/sql"
-
-	"github.com/golang/protobuf/ptypes/timestamp"
-	"onepass.app/facility/hts/common"
+	"time"
 )
 
 // Facility is model for database
@@ -23,8 +21,8 @@ type FacilityRequest struct {
 	ID           int64
 	EventID      int64
 	FacilityID   int64
-	Status       common.Status
+	Status       string
 	RejectReason sql.NullString
-	Start        *timestamp.Timestamp
-	Finish       *timestamp.Timestamp
+	Start        time.Time
+	Finish       time.Time
 }

--- a/internal/model/main.go
+++ b/internal/model/main.go
@@ -1,0 +1,30 @@
+package model
+
+import (
+	"database/sql"
+
+	"github.com/golang/protobuf/ptypes/timestamp"
+	"onepass.app/facility/hts/facility"
+)
+
+// Facility is model for database
+type Facility struct {
+	ID             int64
+	OrganizationID int64
+	Name           string
+	Latitude       int64
+	Longitude      int64
+	OperatingHours sql.NullString
+	Description    sql.NullString
+}
+
+// FacilityRequest is model for database
+type FacilityRequest struct {
+	ID           int64
+	EventID      int64
+	FacilityID   int64
+	Status       facility.RequestStatus
+	RejectReason sql.NullString
+	Start        *timestamp.Timestamp
+	Finish       *timestamp.Timestamp
+}

--- a/internal/typing/main.go
+++ b/internal/typing/main.go
@@ -2,6 +2,7 @@ package typing
 
 import (
 	"google.golang.org/grpc/codes"
+	"onepass.app/facility/hts/common"
 )
 
 // DatabaseError is for database error
@@ -18,3 +19,10 @@ type NotFoundError struct {
 }
 
 func (e *NotFoundError) Error() string { return e.Name + ": not found" }
+
+// PermissionError is a denied permission
+type PermissionError struct {
+	Type common.Permission
+}
+
+func (e *PermissionError) Error() string { return e.Type.String() + " is denied" }

--- a/internal/typing/main.go
+++ b/internal/typing/main.go
@@ -5,6 +5,12 @@ import (
 	"onepass.app/facility/hts/common"
 )
 
+// CustomError is
+type CustomError interface {
+	Code() codes.Code
+	Error() string
+}
+
 // DatabaseError is for database error
 type DatabaseError struct {
 	StatusCode codes.Code
@@ -13,12 +19,18 @@ type DatabaseError struct {
 
 func (e *DatabaseError) Error() string { return e.Err.Error() }
 
+// Code is for getting code
+func (e *DatabaseError) Code() codes.Code { return e.StatusCode }
+
 // NotFoundError is a error for not found
 type NotFoundError struct {
 	Name string
 }
 
 func (e *NotFoundError) Error() string { return e.Name + ": not found" }
+
+// Code is for getting code
+func (e *NotFoundError) Code() codes.Code { return codes.NotFound }
 
 // PermissionError is a denied permission
 type PermissionError struct {
@@ -27,9 +39,15 @@ type PermissionError struct {
 
 func (e *PermissionError) Error() string { return e.Type.String() + " is denied" }
 
+// Code is for getting code
+func (e *PermissionError) Code() codes.Code { return codes.PermissionDenied }
+
 // AlreadyExistError is error for existed entry
 type AlreadyExistError struct {
 	Name string
 }
 
 func (e *AlreadyExistError) Error() string { return e.Name + ": already exist" }
+
+// Code is for getting code
+func (e *AlreadyExistError) Code() codes.Code { return codes.AlreadyExists }

--- a/internal/typing/main.go
+++ b/internal/typing/main.go
@@ -26,3 +26,10 @@ type PermissionError struct {
 }
 
 func (e *PermissionError) Error() string { return e.Type.String() + " is denied" }
+
+// AlreadyExistError is error for existed entry
+type AlreadyExistError struct {
+	Name string
+}
+
+func (e *AlreadyExistError) Error() string { return e.Name + ": already exist" }

--- a/internal/typing/main.go
+++ b/internal/typing/main.go
@@ -1,0 +1,20 @@
+package typing
+
+import (
+	"google.golang.org/grpc/codes"
+)
+
+// DatabaseError is for database error
+type DatabaseError struct {
+	StatusCode codes.Code
+	Err        error
+}
+
+func (e *DatabaseError) Error() string { return e.Err.Error() }
+
+// NotFoundError is a error for not found
+type NotFoundError struct {
+	Name string
+}
+
+func (e *NotFoundError) Error() string { return e.Name + ": not found" }


### PR DESCRIPTION
**Add/Edit new API**
- `GetFacilityInfo` (edit) Now can use CustomError no need for SQL error anymore 
- `ApproveFacilityRequest` (new) Check for permission before approve request
- `RejectFacilityRequest` (new) Check for permission before reject request
- `CreateFacilityRequest` (new) Use go channel to wait for 3 database query before create request

**Add new files**
- Helper file for mock function `hasPermission` and `hasEvent` for mocking account service and organization service.
- `package typing` for custom error. We don't need other layer to understand SQL error anymore
- `package model` for struct**. In future data layer should not understand proto struct
- Helper for function `convertFacilityModelToProto` and `convertFacilityRequestModelToProto`

**Improvements**
- `updateFacilityRequest` to support `ApproveFacilityRequest` and `RejectFacilityRequest`
- use gp string literal for readibility
